### PR TITLE
fixed [2054] Drop down arrow is not clickable when user hovers over it in the "How would you define yourself?" field

### DIFF
--- a/src/components/dropdown/dropdown.module.scss
+++ b/src/components/dropdown/dropdown.module.scss
@@ -59,6 +59,7 @@
       right: 5px;
       fill: $main-dark-color;
       position: absolute;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
fixed [2054] Drop down arrow is not clickable when user hovers over it in the "How would you define yourself?" field