### PR TITLE
[2325] fixed "When user opens "Explore Ecosystem" and "Get Tagions" pages gradient moves from rightside to leftside"

### DIFF
--- a/src/blocks/start-contributing/start-contributing.tsx
+++ b/src/blocks/start-contributing/start-contributing.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react";
 import classNames from "classnames/bind";
 
 import { Button, CustomLink } from "../../components";
-import { ExternalLinks } from "../../common/enums/external_links";
+import { ExternalLinks, PageSizes } from "../../common/enums";
 import { startContributingData } from "../../content";
+import { useResizeEvent } from "../../hooks";
 
 import * as styles from "./start-contributing.module.scss";
 
@@ -11,13 +12,23 @@ const cx = classNames.bind(styles);
 
 export const StartContributingBlock: React.FC = ({}) => {
   const [openedTaskIndex, setOpenedTaskIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(0);
+  useResizeEvent({
+    resizeHandler: () => {
+      setPageSize(window.innerWidth);
+      window.innerWidth >= PageSizes.DESKTOP &&
+        setOpenedTaskIndex((openedTaskIndex) =>
+          openedTaskIndex === -1 ? 0 : openedTaskIndex
+        );
+    },
+  });
 
   const taskHeader = (index: number, taskName: string) => (
     <div
       className={cx("task_header", { isActive: openedTaskIndex === index })}
       onClick={() =>
         setOpenedTaskIndex((openedTaskIndex) =>
-          openedTaskIndex === index ? -1 : index
+          openedTaskIndex === index && pageSize < PageSizes.DESKTOP ? -1 : index
         )
       }
     >

--- a/src/components/gradient-spots-wrapper/gradient-spots-wrapper.tsx
+++ b/src/components/gradient-spots-wrapper/gradient-spots-wrapper.tsx
@@ -74,7 +74,7 @@ export const GradientSpotsWrapper: React.FC<PropsWithChildren<InputProps>> = ({
       gradientImg = gradients.tablet.img(imgArgument);
       gradientOptions = gradients.tablet.options;
     } else if (
-      pageWidth >= 0 &&
+      pageWidth > 0 &&
       pageWidth < PageSizes.TABLET &&
       gradients.mobile
     ) {


### PR DESCRIPTION
fixed "When user opens "Explore Ecosystem" and "Get Tagions" pages gradient moves from rightside to leftside"