### PR TITLE
[2243] fixed "Pages "terms of use" or "privacy policy" scroll down after user click on "back" button in the browser"

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,1 +1,7 @@
 import "./src/styles/index.scss";
+
+export const shouldUpdateScroll = () => {
+  console.log("test - shouldUpdateScroll was executed");
+  window.scrollTo(0, 0);
+  return false;
+};


### PR DESCRIPTION
- added gatsby 'shouldUpdateScroll' function that handle behaviour of saving user position during reloading page