### PR TITLE
fix for 'TypeError: Cannot read properties of undefined (reading 'selectedFilterIndex')' during building

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -21,7 +21,7 @@ interface InputProps {
 
 const BlogPage = ({ location: { state } }: InputProps) => {
   const [selectedFilterIndex, setSelectedFilterIndex] = useState<string>("0");
-  const selectedFilterIndexProp = state["selectedFilterIndex"];
+  const selectedFilterIndexProp = state?.["selectedFilterIndex"];
 
   useEffect(() => {
     selectedFilterIndexProp &&


### PR DESCRIPTION
fix for 'TypeError: Cannot read properties of undefined (reading 'selectedFilterIndex')' during building